### PR TITLE
fix next tab flickering

### DIFF
--- a/src/command-handler.ts
+++ b/src/command-handler.ts
@@ -38,6 +38,7 @@ export default class CommandHandler extends BaseCommandHandler {
   }
 
   async focus(): Promise<any> {
+    this.updateActiveEditor();
     if (!this.activeEditor) {
       return;
     }
@@ -101,12 +102,7 @@ export default class CommandHandler extends BaseCommandHandler {
 
   pollActiveEditor() {
     setInterval(() => {
-      const editor = vscode.window.activeTextEditor;
-      if (!editor) {
-        return;
-      }
-
-      this.activeEditor = editor;
+      this.updateActiveEditor();
     }, 1000);
   }
 
@@ -159,6 +155,15 @@ export default class CommandHandler extends BaseCommandHandler {
     }
 
     this.activeEditor!.selections = [new vscode.Selection(row, column, row, column)];
+  }
+
+  updateActiveEditor() {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      return;
+    }
+
+    this.activeEditor = editor;
   }
 
   async COMMAND_TYPE_CLOSE_TAB(_data: any): Promise<any> {


### PR DESCRIPTION
When you say "next tab two times", vs code flickers between the two tabs
and only ends up moving one over. Originally we thought this might be
the UI delay being too short, but I saw this behavior at 250ms+, which
is too long. It looks like the problem is that we're focusing the old
tab because the active editor isn't updated frequently enough, so this
change makes focus check that first.