### PR TITLE
Smart insertion for better experience with language servers 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "bufferutil": "^4.0.1",
+    "diff": "^5.0.0",
     "gitignore-globs": "^0.1.1",
     "mkdirp": "0.5.1",
     "utf-8-validate": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "bufferutil": "^4.0.1",
-    "diff": "^5.0.0",
     "gitignore-globs": "^0.1.1",
     "mkdirp": "0.5.1",
     "utf-8-validate": "^5.0.2",

--- a/src/command-handler.ts
+++ b/src/command-handler.ts
@@ -129,7 +129,7 @@ export default class CommandHandler {
       }
     }
   }
-  
+
   private async setSourceAndCursor(before: string, source: string, row: number, column: number): Promise<void> {
     if (!this.activeEditor) {
       return;
@@ -151,7 +151,6 @@ export default class CommandHandler {
 
     this.activeEditor.selections = [new vscode.Selection(row, column, row, column)];
   }
-
 
   private async uiDelay(timeout: number = 100): Promise<void> {
     return new Promise((resolve) => {

--- a/src/command-handler.ts
+++ b/src/command-handler.ts
@@ -129,7 +129,7 @@ export default class CommandHandler {
       }
     }
   }
-
+  
   private async setSourceAndCursor(before: string, source: string, row: number, column: number): Promise<void> {
     if (!this.activeEditor) {
       return;
@@ -137,19 +137,13 @@ export default class CommandHandler {
 
     if (before != source) {
       await this.activeEditor.edit((edit) => {
-        const firstLine = this.activeEditor!.document.lineAt(0);
-        const lastLine = this.activeEditor!.document.lineAt(
-          this.activeEditor!.document.lineCount - 1
-        );
-
-        const textRange = new vscode.Range(
-          0,
-          firstLine.range.start.character,
-          this.activeEditor!.document.lineCount - 1,
-          lastLine.range.end.character
-        );
-
-        edit.replace(textRange, source);
+        for (const change of diff.codeDiff(before, source)) {
+          if (change.insertion) {
+            edit.insert(new vscode.Position(change.row , change.column), change.text)
+          } else {
+            edit.delete(new vscode.Range(change.r1, change.c1, change.r2, change.c2))
+          }
+        }
       });
     }
 

--- a/src/command-handler.ts
+++ b/src/command-handler.ts
@@ -137,18 +137,21 @@ export default class CommandHandler {
 
     if (before != source) {
       await this.activeEditor.edit((edit) => {
-        for (const change of diff.codeDiff(before, source)) {
-          if (change.insertion) {
-            edit.insert(new vscode.Position(change.row , change.column), change.text)
-          } else {
-            edit.delete(new vscode.Range(change.r1, change.c1, change.r2, change.c2))
-          }
-        }
+        const {
+          start_row,
+          start_column,
+          stop_row,
+          stop_column,
+          insertion_text
+        } = diff.codeDiff(before, source);
+
+        edit.replace(new vscode.Range(start_row, start_column, stop_row, stop_column), insertion_text)
       });
     }
 
     this.activeEditor.selections = [new vscode.Selection(row, column, row, column)];
   }
+
 
   private async uiDelay(timeout: number = 100): Promise<void> {
     return new Promise((resolve) => {

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -97,7 +97,7 @@ export function cursorToRowAndColumn(source: string, cursor: number): number[] {
 
 /**
  * Computes the differences between two strings in a way that vscode
- * can then use "replace" only the modified text.
+ * can then "replace" only the modified text.
  * 
  * @param before The string before the change.
  * @param after The string after the change.

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -126,6 +126,15 @@ export function codeDiff(before: string, after: string): any {
     if (before[i] !== after[i]) {
       break;
     }
+
+    // Compute the row and column of the start of the change
+    if (before[i] === "\n") {
+      start_row += 1;
+      start_column = 0;
+    } else {
+      start_column += 1;
+    }
+
     start_index = i + 1;
   }
 
@@ -135,16 +144,6 @@ export function codeDiff(before: string, after: string): any {
       break;
     }
     stop_index = i;
-  }
-
-  // Compute the row and column of the start of the change
-  for (let i = 0; i < start_index; i++) {
-    if (before[i] === "\n") {
-      start_row += 1;
-      start_column = 0;
-    } else {
-      start_column += 1;
-    }
   }
 
   // update stop_row and stop_column to match start_row and start_column

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,5 +1,4 @@
 const DiffMatchPatch = require("./diff_match_patch");
-const { diffLines } = require("diff");
 
 export enum DiffRangeType {
   Add,


### PR DESCRIPTION
The current serenade application replaces the entire text inside VS Code whenever a change is made. This results in a negative user experience when using certain applications that rely on a language server. In particular, when using Rust-analyzer, any changes that were made would result in all of the types going away and having to be re-loaded/re-computed.

This pull request adds the functionality to compare the differences between the old and new files. A change list is then made and each one is applied. Local testing seems to show that this is working well and rust analyzer no longer complains. There seem to be no regressions.

I doubt this code is up to your internal standards and encourage you to edit it and make changes.

There is an open question  whether or not we will ever see disparate changes. In this code, after the deletion section of the difference, the columns and rows are reset back to their previous value to mimic what would happen when the text is deleted. I believe this is unnecessary as serenade will only ever make one change at a time, so this code could be optimized or changed a bit. 