### PR TITLE
 Smart insertion for better experience with language servers v2

### DIFF
--- a/src/command-handler.ts
+++ b/src/command-handler.ts
@@ -1,4 +1,3 @@
-import { cursorTo } from "readline";
 import * as vscode from "vscode";
 import * as diff from "./diff";
 import Settings from "./settings";


### PR DESCRIPTION
This diff iterates on what @[cgburgess](https://github.com/cgburgess) figured out in this diff: https://github.com/serenadeai/code/pull/39

The code code block added currently takes <1ms on large files, so this seems like the appropriate tradeoff with regard to code complexity.